### PR TITLE
Uses [].slice to copy array instead of Array.from.

### DIFF
--- a/addon/utils/computable-promise.js
+++ b/addon/utils/computable-promise.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import DS from 'ember-data';
 
 function computablePromise() {
-  let args = Array.from(arguments);
+  let args = [].slice.call(arguments);
   let fn = args.pop();
   let fnAsPromiseObject = function() {
     let promise = fn.apply(this);


### PR DESCRIPTION
Due to compatibility issues.