### PR TITLE
Creates and tests an `isLoadingComputablePromise` function.

### DIFF
--- a/addon/utils/computable-promise.js
+++ b/addon/utils/computable-promise.js
@@ -25,4 +25,8 @@ function computablePromiseValue(promiseProp) {
   });
 }
 
-export {computablePromise, computablePromiseValue};
+function isLoadingComputablePromise(promiseProp) {
+  return Ember.computed.alias(`${promiseProp}.isPending`);
+}
+
+export {computablePromise, computablePromiseValue, isLoadingComputablePromise};

--- a/tests/unit/utils/computable-promise-test.js
+++ b/tests/unit/utils/computable-promise-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { computablePromise, computablePromiseValue } from 'ember-computable-promise/utils/computable-promise';
+import { computablePromise, computablePromiseValue, isLoadingComputablePromise } from 'ember-computable-promise/utils/computable-promise';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | computable promise');
@@ -23,6 +23,28 @@ test('computablePromise works with computablePromiseValue', function(assert) {
     assert.strictEqual(obj.get('myComputablePromiseValue'), undefined, 'computedPromiseValue is undefined before promise resolution');
     obj.get('myComputablePromise').then(() => {
       assert.strictEqual(obj.get('myComputablePromiseValue'), expectedValue, 'computedPromiseValue has the resolved value of computedPromise after resolution');
+    });
+  });
+});
+
+test('computablePromise works with isLoadingComputablePromise', function(assert) {
+  let Obj = Ember.Object.extend({
+    someVal: 'foo',
+    myComputablePromise: computablePromise('someVal', function() {
+      let resolvedVal = this.get('someVal');
+      return new Ember.RSVP.Promise(resolve => {
+        resolve(resolvedVal);
+      });
+    }),
+    isLoading: isLoadingComputablePromise('myComputablePromise')
+  });
+  let obj = Obj.create();
+
+  Ember.run(function() {
+    obj.get('myComputablePromise').then(() => {
+      assert.strictEqual(obj.get('isLoading'), false, 'isLoadingComputablePromise is false once promise has resolved');
+      obj.set('someVal', 'bar');
+      assert.strictEqual(obj.get('isLoading'), true, 'isLoadingComputablePromise is true when promise is fired again');
     });
   });
 });


### PR DESCRIPTION
We already do this in our app - I just think it would be cleaner to have a function for it (rather than accessing the private `isPending` attribute directly).